### PR TITLE
feat(functional-parameters): add support for ignoring selector prefixes

### DIFF
--- a/docs/rules/functional-parameters.md
+++ b/docs/rules/functional-parameters.md
@@ -56,6 +56,7 @@ type Options = {
     ignoreIIFE: boolean;
   };
   ignorePattern?: string[] | string;
+  ignorePrefixSelector?: string[] | string;
 }
 ```
 
@@ -135,6 +136,31 @@ See [enforceParameterCount](#enforceparametercount).
 #### `enforceParameterCount.ignoreIIFE`
 
 If true, this option allows for the use of [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) that do not have any parameters.
+
+### `ignorePrefixSelector`
+
+This allows for ignore functions where one of the given selectors matches the parent node in the AST of the function node.\
+For more information see [ESLint Selectors](https://eslint.org/docs/developer-guide/selectors).
+
+Example:
+
+With the following config:
+
+```json
+{
+  "enforceParameterCount": "exactlyOne",
+  "ignorePrefixSelector": "CallExpression[callee.property.name='reduce']"
+},
+```
+
+The following inline callback won't be flagged:
+
+```js
+const sum = [1, 2, 3].reduce(
+  (carry, current) => current,
+  0
+);
+```
 
 ### `ignorePattern`
 

--- a/src/common/ignore-options.ts
+++ b/src/common/ignore-options.ts
@@ -109,6 +109,25 @@ export const ignoreInterfaceOptionSchema: JSONSchema4["properties"] = {
 };
 
 /**
+ * The option to ignore prefix selector.
+ */
+export type IgnorePrefixSelectorOption = {
+  readonly ignorePrefixSelector?: ReadonlyArray<string> | string;
+};
+
+/**
+ * The schema for the option to ignore prefix selector.
+ */
+export const ignorePrefixSelectorOptionSchema: JSONSchema4["properties"] = {
+  ignorePrefixSelector: {
+    type: ["string", "array"],
+    items: {
+      type: "string",
+    },
+  },
+};
+
+/**
  * Should the given text be allowed?
  *
  * Test using the given pattern(s).

--- a/tests/rules/functional-parameters/es3/invalid.ts
+++ b/tests/rules/functional-parameters/es3/invalid.ts
@@ -99,6 +99,37 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  {
+    code: dedent`
+      [1, 2, 3]
+        .map(
+          function(element, index) {
+            return element + index;
+          }
+        )
+        .reduce(
+          function(carry, current) {
+            return carry + current;
+          },
+          0
+        );
+    `,
+    optionsSet: [[{ enforceParameterCount: "exactlyOne" }]],
+    errors: [
+      {
+        messageId: "paramCountExactlyOne",
+        type: "FunctionExpression",
+        line: 3,
+        column: 5,
+      },
+      {
+        messageId: "paramCountExactlyOne",
+        type: "FunctionExpression",
+        line: 8,
+        column: 5,
+      },
+    ],
+  },
 ];
 
 export default tests;

--- a/tests/rules/functional-parameters/es3/valid.ts
+++ b/tests/rules/functional-parameters/es3/valid.ts
@@ -42,6 +42,69 @@ const tests: ReadonlyArray<ValidTestCase> = [
       [{ ignorePattern: "^foo", enforceParameterCount: "exactlyOne" }],
     ],
   },
+  {
+    code: dedent`
+      [1, 2, 3].reduce(
+        function(carry, current) {
+          return carry + current;
+        },
+        0
+      );
+    `,
+    optionsSet: [
+      [
+        {
+          ignorePrefixSelector: "CallExpression[callee.property.name='reduce']",
+          enforceParameterCount: "exactlyOne",
+        },
+      ],
+    ],
+  },
+  {
+    code: dedent`
+      [1, 2, 3].map(
+        function(element, index) {
+          return element + index;
+        },
+        0
+      );
+    `,
+    optionsSet: [
+      [
+        {
+          enforceParameterCount: "exactlyOne",
+          ignorePrefixSelector: "CallExpression[callee.property.name='map']",
+        },
+      ],
+    ],
+  },
+  {
+    code: dedent`
+      [1, 2, 3]
+        .map(
+          function(element, index) {
+            return element + index;
+          }
+        )
+        .reduce(
+          function(carry, current) {
+            return carry + current;
+          },
+          0
+        );
+    `,
+    optionsSet: [
+      [
+        {
+          enforceParameterCount: "exactlyOne",
+          ignorePrefixSelector: [
+            "CallExpression[callee.property.name='reduce']",
+            "CallExpression[callee.property.name='map']",
+          ],
+        },
+      ],
+    ],
+  },
 ];
 
 export default tests;

--- a/tests/rules/functional-parameters/es6/valid.ts
+++ b/tests/rules/functional-parameters/es6/valid.ts
@@ -37,6 +37,60 @@ const tests: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[{ ignorePattern: "^foo" }]],
   },
+  {
+    code: dedent`
+      [1, 2, 3].reduce(
+        (carry, current) => carry + current,
+        0
+      );
+    `,
+    optionsSet: [
+      [
+        {
+          enforceParameterCount: "exactlyOne",
+          ignorePrefixSelector: "CallExpression[callee.property.name='reduce']",
+        },
+      ],
+    ],
+  },
+  {
+    code: dedent`
+      [1, 2, 3].map(
+        (element, index) => element + index,
+        0
+      );
+    `,
+    optionsSet: [
+      [
+        {
+          enforceParameterCount: "exactlyOne",
+          ignorePrefixSelector: "CallExpression[callee.property.name='map']",
+        },
+      ],
+    ],
+  },
+  {
+    code: dedent`
+      [1, 2, 3]
+        .map(
+          (element, index) => element + index
+        )
+        .reduce(
+          (carry, current) => carry + current, 0
+        );
+    `,
+    optionsSet: [
+      [
+        {
+          enforceParameterCount: "exactlyOne",
+          ignorePrefixSelector: [
+            "CallExpression[callee.property.name='reduce']",
+            "CallExpression[callee.property.name='map']",
+          ],
+        },
+      ],
+    ],
+  },
 ];
 
 export default tests;


### PR DESCRIPTION
re #207
re #244

This allows for ignoring functions where one of the given selectors matches the parent node in the AST of the function's node.
For more information see [ESLint Selectors](https://eslint.org/docs/developer-guide/selectors).

Example:

With the following config:

```json
{
  "enforceParameterCount": "exactlyOne",
  "ignorePrefixSelector": "CallExpression[callee.property.name='reduce']"
},
```

The following inline callback won't be flaged:

```js
const sum = [1, 2, 3].reduce(
  (carry, current) => carry + current,
  0
);`,
```