### PR TITLE
chore: master => main

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,7 +3,7 @@ name: Sync labels
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - master
+      - main
       - next
 
 jobs:

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 branches:
-  - master
+  - main
   - name: next
     channel: next
     prerelease: beta

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm version](https://img.shields.io/npm/v/eslint-plugin-functional.svg?style=flat)](https://www.npmjs.com/package/eslint-plugin-functional)
 [![CI](https://github.com/jonaskello/eslint-plugin-functional/actions/workflows/ci.yml/badge.svg)](https://github.com/jonaskello/eslint-plugin-functional/actions/workflows/ci.yml)
-[![Coverage Status](https://codecov.io/gh/jonaskello/eslint-plugin-functional/branch/master/graph/badge.svg)](https://codecov.io/gh/jonaskello/eslint-plugin-functional)
+[![Coverage Status](https://codecov.io/gh/jonaskello/eslint-plugin-functional/branch/main/graph/badge.svg)](https://codecov.io/gh/jonaskello/eslint-plugin-functional)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat)](https://github.com/semantic-release/semantic-release)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
 [![MIT license](https://img.shields.io/github/license/jonaskello/eslint-plugin-functional.svg?style=flat)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Changes configs to use "main" branch over "master".

Once merged, the default branch needs to be changed to "main" in the repo's settings. The master branch can then be delete.

@jonaskello Can you merge this and make that settings change?