### PR TITLE
feat(prefer-tacit): add allowTypeParameters option to allow function calls that specify type params

### DIFF
--- a/docs/rules/prefer-tacit.md
+++ b/docs/rules/prefer-tacit.md
@@ -39,11 +39,12 @@ This rule accepts an options object of the following type:
 
 ```ts
 type Options = {
-  assumeTypes:
+  assumeTypes?:
     | false
     | {
         allowFixer: boolean;
-      }
+      };
+  allowTypeParameters?: boolean;
   ignorePattern?: string[] | string;
 }
 ```
@@ -53,6 +54,7 @@ The default options:
 ```ts
 const defaults = {
   assumeTypes: false,
+  allowTypeParameters: false
 };
 ```
 
@@ -78,6 +80,18 @@ When set types will be assumed.
 
 This option states whether the auto fixer should be enabled for violations that are found when assuming types (violations found without assuming types will ignore this option).
 Because when assuming types, false positives may be found, it's recommended to set this option to `false`.
+
+### `allowTypeParameters`
+
+This option is only useful when using TypeScript. This rule doesn’t inspect type parameters when calling generic function with one ore more type parameters by default.
+
+```ts
+function foo<T>() {}
+const bar = () => foo<string>();
+```
+
+This example causes a problem to be reported when `allowTypeParameters` is `false`.
+Setting `allowTypeParameters` to `true` will allow functions to call another function while specifying the type parameters.
 
 ### `ignorePattern`
 

--- a/src/rules/prefer-tacit.ts
+++ b/src/rules/prefer-tacit.ts
@@ -34,6 +34,7 @@ type Options = readonly [
         | Readonly<{
             allowFixer: boolean;
           }>;
+      allowTypeParameters: boolean;
     }>
 ];
 
@@ -64,6 +65,9 @@ const schema: JSONSchema4 = [
           },
         ],
       },
+      allowTypeParameters: {
+        type: "boolean",
+      },
     }),
     additionalProperties: false,
   },
@@ -75,6 +79,7 @@ const schema: JSONSchema4 = [
 const defaultOptions: Options = [
   {
     assumeTypes: false,
+    allowTypeParameters: false,
   },
 ];
 
@@ -150,7 +155,15 @@ function getCallDescriptors(
   options: Options,
   caller: ReadonlyDeep<TSESTree.CallExpression>
 ): Array<ReadonlyDeep<TSESLint.ReportDescriptor<keyof typeof errorMessages>>> {
-  const [{ assumeTypes }] = options;
+  const [{ assumeTypes, allowTypeParameters }] = options;
+
+  if (
+    allowTypeParameters &&
+    caller.typeParameters !== undefined &&
+    caller.typeParameters.params.length > 0
+  ) {
+    return [];
+  }
 
   if (
     isIdentifier(caller.callee) &&

--- a/tests/rules/prefer-tacit/ts/invalid.ts
+++ b/tests/rules/prefer-tacit/ts/invalid.ts
@@ -105,6 +105,26 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  // Type parameters when allowTypeParameters is false
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      const foo = x => f<number>(x);
+    `,
+    optionsSet: [[{ allowTypeParameters: false }]],
+    output: dedent`
+      function f<T>(x: T): T {}
+      const foo = f;
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "ArrowFunctionExpression",
+        line: 2,
+        column: 13,
+      },
+    ],
+  },
 ];
 
 export default tests;

--- a/tests/rules/prefer-tacit/ts/valid.ts
+++ b/tests/rules/prefer-tacit/ts/valid.ts
@@ -36,6 +36,14 @@ const tests: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
+  // Type parameters when allowTypeParameters is false
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      const foo = x => f<number>(x);
+    `,
+    optionsSet: [[{ allowTypeParameters: true }]],
+  },
 ];
 
 export default tests;


### PR DESCRIPTION
This adds a new option `allowTypeParameters` to `prefer-tacit` that allows function calls that specify the type parameters of a generic function.

For example, I have a `createEventEmitter` function which accepts a type parameter that specifies the event mapping:

```ts
type MyEventMapping = { myEventName: { myEventPayloadProperty: number } };
const myEventEmitter = createEventEmitter<MyEventMapping>();
```

Since I need to create those emitters quite often I think it is handy to have a function that specifies the type parameter like this:

```ts
function createMyEventEmitter() {
  return createEventEmitter<MyEventMapping>();
}
```

But this gets always reported as a problem by the `prefer-tacit` rule. That’s why I’m suggesting to add an option that allows this when type parameter are used during a function call.