### PR TITLE
feat(prefer-tacit): support autofixing function calls with type parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   "dependencies": {
     "@typescript-eslint/utils": "^5.10.2",
     "deepmerge-ts": "^4.0.3",
-    "escape-string-regexp": "^4.0.0"
+    "escape-string-regexp": "^4.0.0",
+    "semver": "^7.3.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
@@ -87,6 +88,7 @@
     "@types/estree": "^0.0.51",
     "@types/node": "18.0.0",
     "@types/rollup-plugin-auto-external": "^2.0.2",
+    "@types/semver": "^7.3.12",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
     "ava": "^4.0.1",

--- a/tests/rules/prefer-tacit/index.test.ts
+++ b/tests/rules/prefer-tacit/index.test.ts
@@ -1,9 +1,26 @@
+import * as semver from "semver";
+
+import ts from "~/conditional-imports/typescript";
 import { name, rule } from "~/rules/prefer-tacit";
 import { testUsing } from "~/tests/helpers/testers";
 
 import es3Tests from "./es3";
 import es6Tests from "./es6";
 import tsTests from "./ts";
+import ts4Dot7Tests from "./ts4.7";
+import tsNot4Dot7Tests from "./tsNot4.7";
+
+const isTS4dot7 =
+  ts !== undefined &&
+  semver.satisfies(ts.version, `>= 4.7.0 || >= 4.7.1-rc || >= 4.7.0-beta`, {
+    includePrerelease: true,
+  });
+
+if (isTS4dot7) {
+  testUsing.typescript(name, rule, ts4Dot7Tests);
+} else {
+  testUsing.typescript(name, rule, tsNot4Dot7Tests);
+}
 
 testUsing.typescript(name, rule, tsTests);
 testUsing.typescript(name, rule, es6Tests);

--- a/tests/rules/prefer-tacit/ts/invalid.ts
+++ b/tests/rules/prefer-tacit/ts/invalid.ts
@@ -148,44 +148,6 @@ const tests: ReadonlyArray<InvalidTestCase> = [
   {
     code: dedent`
       function f<T>(x: T): T {}
-      const foo = x => f<number>(x);
-    `,
-    optionsSet: [[]],
-    output: dedent`
-      function f<T>(x: T): T {}
-      const foo = f<number>;
-    `,
-    errors: [
-      {
-        messageId: "generic",
-        type: "ArrowFunctionExpression",
-        line: 2,
-        column: 13,
-      },
-    ],
-  },
-  {
-    code: dedent`
-      function f<T>(x: T): T {}
-      function foo(x) { return f<number>(x); }
-    `,
-    optionsSet: [[]],
-    output: dedent`
-      function f<T>(x: T): T {}
-      const foo = f<number>;
-    `,
-    errors: [
-      {
-        messageId: "generic",
-        type: "FunctionDeclaration",
-        line: 2,
-        column: 1,
-      },
-    ],
-  },
-  {
-    code: dedent`
-      function f<T>(x: T): T {}
       export default function (x) { return f<number>(x); }
     `,
     optionsSet: [[]],

--- a/tests/rules/prefer-tacit/ts/invalid.ts
+++ b/tests/rules/prefer-tacit/ts/invalid.ts
@@ -144,6 +144,64 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       },
     ],
   },
+  // Type parameters
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      const foo = x => f<number>(x);
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f<T>(x: T): T {}
+      const foo = f<number>;
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "ArrowFunctionExpression",
+        line: 2,
+        column: 13,
+      },
+    ],
+  },
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      function foo(x) { return f<number>(x); }
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f<T>(x: T): T {}
+      const foo = f<number>;
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "FunctionDeclaration",
+        line: 2,
+        column: 1,
+      },
+    ],
+  },
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      export default function (x) { return f<number>(x); }
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f<T>(x: T): T {}
+      export default function (x) { return f<number>(x); }
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "FunctionDeclaration",
+        line: 2,
+        column: 16,
+      },
+    ],
+  },
 ];
 
 export default tests;

--- a/tests/rules/prefer-tacit/ts/valid.ts
+++ b/tests/rules/prefer-tacit/ts/valid.ts
@@ -36,6 +36,13 @@ const tests: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
+  // Instantiation Expression
+  {
+    code: dedent`
+      const foo = f<number>;
+    `,
+    optionsSet: [[]],
+  },
 ];
 
 export default tests;

--- a/tests/rules/prefer-tacit/ts/valid.ts
+++ b/tests/rules/prefer-tacit/ts/valid.ts
@@ -36,13 +36,6 @@ const tests: ReadonlyArray<ValidTestCase> = [
     `,
     optionsSet: [[]],
   },
-  // Instantiation Expression
-  {
-    code: dedent`
-      const foo = f<number>;
-    `,
-    optionsSet: [[]],
-  },
 ];
 
 export default tests;

--- a/tests/rules/prefer-tacit/ts4.7/index.ts
+++ b/tests/rules/prefer-tacit/ts4.7/index.ts
@@ -1,0 +1,7 @@
+import invalid from "./invalid";
+import valid from "./valid";
+
+export default {
+  valid,
+  invalid,
+};

--- a/tests/rules/prefer-tacit/ts4.7/invalid.ts
+++ b/tests/rules/prefer-tacit/ts4.7/invalid.ts
@@ -1,0 +1,47 @@
+import dedent from "dedent";
+
+import type { InvalidTestCase } from "~/tests/helpers/util";
+
+const tests: ReadonlyArray<InvalidTestCase> = [
+  // Instantiation Expression
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      const foo = x => f<number>(x);
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f<T>(x: T): T {}
+      const foo = f<number>;
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "ArrowFunctionExpression",
+        line: 2,
+        column: 13,
+      },
+    ],
+  },
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      function foo(x) { return f<number>(x); }
+    `,
+    optionsSet: [[]],
+    output: dedent`
+      function f<T>(x: T): T {}
+      const foo = f<number>;
+    `,
+    errors: [
+      {
+        messageId: "generic",
+        type: "FunctionDeclaration",
+        line: 2,
+        column: 1,
+      },
+    ],
+  },
+];
+
+export default tests;

--- a/tests/rules/prefer-tacit/ts4.7/valid.ts
+++ b/tests/rules/prefer-tacit/ts4.7/valid.ts
@@ -1,0 +1,15 @@
+import dedent from "dedent";
+
+import type { ValidTestCase } from "~/tests/helpers/util";
+
+const tests: ReadonlyArray<ValidTestCase> = [
+  // Instantiation Expression
+  {
+    code: dedent`
+      const foo = f<number>;
+    `,
+    optionsSet: [[]],
+  },
+];
+
+export default tests;

--- a/tests/rules/prefer-tacit/tsNot4.7/index.ts
+++ b/tests/rules/prefer-tacit/tsNot4.7/index.ts
@@ -1,0 +1,7 @@
+import invalid from "./invalid";
+import valid from "./valid";
+
+export default {
+  valid,
+  invalid,
+};

--- a/tests/rules/prefer-tacit/tsNot4.7/invalid.ts
+++ b/tests/rules/prefer-tacit/tsNot4.7/invalid.ts
@@ -1,0 +1,24 @@
+import dedent from "dedent";
+
+import type { InvalidTestCase } from "~/tests/helpers/util";
+
+const tests: ReadonlyArray<InvalidTestCase> = [
+  // Instantiation Expression not supported.
+  {
+    code: dedent`
+      function f<T>(x: T): T {}
+      function foo(x) { return f<number>(x); }
+    `,
+    optionsSet: [[]],
+    errors: [
+      {
+        messageId: "generic",
+        type: "FunctionDeclaration",
+        line: 2,
+        column: 1,
+      },
+    ],
+  },
+];
+
+export default tests;

--- a/tests/rules/prefer-tacit/tsNot4.7/valid.ts
+++ b/tests/rules/prefer-tacit/tsNot4.7/valid.ts
@@ -1,0 +1,7 @@
+import dedent from "dedent";
+
+import type { ValidTestCase } from "~/tests/helpers/util";
+
+const tests: ReadonlyArray<ValidTestCase> = [];
+
+export default tests;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,6 +1739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.3.12":
+  version: 7.3.12
+  resolution: "@types/semver@npm:7.3.12"
+  checksum: 35536b2fc5602904f21cae681f6c9498e177dab3f54ae37c92f9a1b7e43c35f18bcd81e1c98c1cf0d33ee046bb06c771e9928c1c00a401d56a03f56549252a15
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:*, @types/unist@npm:^2.0.2":
   version: 2.0.6
   resolution: "@types/unist@npm:2.0.6"
@@ -4091,6 +4098,7 @@ __metadata:
     "@types/estree": ^0.0.51
     "@types/node": 18.0.0
     "@types/rollup-plugin-auto-external": ^2.0.2
+    "@types/semver": ^7.3.12
     "@typescript-eslint/eslint-plugin": ^5.10.2
     "@typescript-eslint/parser": ^5.10.2
     "@typescript-eslint/utils": ^5.10.2
@@ -4135,6 +4143,7 @@ __metadata:
     rollup: ^2.67.0
     rollup-plugin-auto-external: ^2.0.0
     semantic-release: ^19.0.2
+    semver: ^7.3.7
     ts-node: ^10.4.0
     tsc-prog: ^2.2.1
     tsconfig-paths: ^3.12.0


### PR DESCRIPTION
As discussed in #405, this PR extends the autofixer of `prefer-tacit`, so that function calls with type parameters get transformed to instantiation expressions.

For example:

```ts
function createMyEventEmitter() {
  return createEventEmitter<MyEventMapping>();
}
```

gets transformed to

```ts
const createMyEventEmitter = createEventEmitter<MyEventMapping>;
```