### PR TITLE
fix(type-declaration-immutability): only allow strings to be given for identifiers

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -60,17 +60,17 @@ const overrides: Linter.Config = {
       {
         rules: [
           {
-            identifiers: [/^I?Immutable.+/u],
+            identifiers: ["^I?Immutable.+"],
             immutability: Immutability.Immutable,
             comparator: RuleEnforcementComparator.AtLeast,
           },
           {
-            identifiers: [/^I?ReadonlyDeep.+/u],
+            identifiers: ["^I?ReadonlyDeep.+"],
             immutability: Immutability.ReadonlyDeep,
             comparator: RuleEnforcementComparator.AtLeast,
           },
           {
-            identifiers: [/^I?Readonly.+/u],
+            identifiers: ["^I?Readonly.+"],
             immutability: Immutability.ReadonlyShallow,
             comparator: RuleEnforcementComparator.AtLeast,
             fixer: [
@@ -85,7 +85,7 @@ const overrides: Linter.Config = {
             ],
           },
           {
-            identifiers: [/^I?Mutable.+/u],
+            identifiers: ["^I?Mutable.+"],
             immutability: Immutability.Mutable,
             comparator: RuleEnforcementComparator.AtMost,
             fixer: [

--- a/src/rules/type-declaration-immutability.ts
+++ b/src/rules/type-declaration-immutability.ts
@@ -43,7 +43,7 @@ type FixerConfig = {
 type Options = [
   IgnorePatternOption & {
     rules: Array<{
-      identifiers: (string | RegExp) | Array<string | RegExp>;
+      identifiers: string | string[];
       immutability: Exclude<
         Immutability | keyof typeof Immutability,
         "Unknown"
@@ -101,9 +101,9 @@ const schema: JSONSchema4 = [
           type: "object",
           properties: {
             identifiers: {
-              type: ["string", "object", "array"],
+              type: ["string", "array"],
               items: {
-                type: ["string", "object"],
+                type: ["string"],
               },
             },
             immutability: {
@@ -139,7 +139,7 @@ const defaultOptions: Options = [
   {
     rules: [
       {
-        identifiers: [/^(?!I?Mutable).+/u],
+        identifiers: ["^(?!I?Mutable).+"],
         immutability: Immutability.Immutable,
         comparator: RuleEnforcementComparator.AtLeast,
       },
@@ -201,14 +201,8 @@ function getRules(options: Options): ImmutabilityRule[] {
 
   return rulesOptions.map((rule): ImmutabilityRule => {
     const identifiers = Array.isArray(rule.identifiers)
-      ? rule.identifiers.map((id) =>
-          id instanceof RegExp ? id : new RegExp(id, "u")
-        )
-      : [
-          rule.identifiers instanceof RegExp
-            ? rule.identifiers
-            : new RegExp(rule.identifiers, "u"),
-        ];
+      ? rule.identifiers.map((id) => new RegExp(id, "u"))
+      : [new RegExp(rule.identifiers, "u")];
 
     const immutability =
       typeof rule.immutability === "string"

--- a/tests/rules/type-declaration-immutability/ts/invalid.ts
+++ b/tests/rules/type-declaration-immutability/ts/invalid.ts
@@ -6,17 +6,17 @@ import type { InvalidTestCase } from "~/tests/helpers/util";
 const recommended = {
   rules: [
     {
-      identifiers: [/^I?Immutable.+/u],
+      identifiers: ["^I?Immutable.+"],
       immutability: Immutability.Immutable,
       comparator: "AtLeast",
     },
     {
-      identifiers: [/^I?ReadonlyDeep.+/u],
+      identifiers: ["^I?ReadonlyDeep.+"],
       immutability: Immutability.ReadonlyDeep,
       comparator: "AtLeast",
     },
     {
-      identifiers: [/^I?Readonly.+/u],
+      identifiers: ["^I?Readonly.+"],
       immutability: Immutability.ReadonlyShallow,
       comparator: "AtLeast",
       fixer: [
@@ -31,7 +31,7 @@ const recommended = {
       ],
     },
     {
-      identifiers: [/^I?Mutable.+/u],
+      identifiers: ["^I?Mutable.+"],
       immutability: Immutability.Mutable,
       comparator: "AtMost",
       fixer: [

--- a/tests/rules/type-declaration-immutability/ts/valid.ts
+++ b/tests/rules/type-declaration-immutability/ts/valid.ts
@@ -6,22 +6,22 @@ import type { ValidTestCase } from "~/tests/helpers/util";
 const recommended = {
   rules: [
     {
-      identifiers: [/^I?Immutable.+/u],
+      identifiers: ["^I?Immutable.+"],
       immutability: Immutability.Immutable,
       comparator: "AtLeast",
     },
     {
-      identifiers: [/^I?ReadonlyDeep.+/u],
+      identifiers: ["^I?ReadonlyDeep.+"],
       immutability: Immutability.ReadonlyDeep,
       comparator: "AtLeast",
     },
     {
-      identifiers: [/^I?Readonly.+/u],
+      identifiers: ["^I?Readonly.+"],
       immutability: Immutability.ReadonlyShallow,
       comparator: "AtLeast",
     },
     {
-      identifiers: [/^I?Mutable.+/u],
+      identifiers: ["^I?Mutable.+"],
       immutability: Immutability.Mutable,
       comparator: "AtMost",
     },


### PR DESCRIPTION
`RegExp` doesn't get handle correctly by eslint
