### PR TITLE
feat(prefer-immutable-types)!: use suggestions instead of a fixer by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The [below section](#rules) gives details on which rules are enabled by each rul
 | :--------------------------------------------------------------------------- | :-------------------------------------------------------------- | :------------------------------- | :-- | :-- | :-- | :-- | :-- |
 | [immutable-data](docs/rules/immutable-data.md)                               | Enforce treating data as immutable.                             | ☑️ ✅ 🔒 ![badge-no-mutations][] |     |     |     |     |     |
 | [no-let](docs/rules/no-let.md)                                               | Disallow mutable variables.                                     | ☑️ ✅ 🔒 ![badge-no-mutations][] |     |     |     |     |     |
-| [prefer-immutable-types](docs/rules/prefer-immutable-types.md)               | Require function parameters to be typed as certain immutability | ☑️ ✅ 🔒 ![badge-no-mutations][] |     |     | 🔧  |     |     |
+| [prefer-immutable-types](docs/rules/prefer-immutable-types.md)               | Require function parameters to be typed as certain immutability | ☑️ ✅ 🔒 ![badge-no-mutations][] |     |     | 🔧  | 💡  |     |
 | [prefer-readonly-type](docs/rules/prefer-readonly-type.md)                   | Prefer readonly types over mutable types.                       |                                  |     |     | 🔧  |     | ❌  |
 | [type-declaration-immutability](docs/rules/type-declaration-immutability.md) | Enforce the immutability of types based on patterns.            | ☑️ ✅ 🔒 ![badge-no-mutations][] |     |     | 🔧  |     |     |
 

--- a/docs/rules/prefer-immutable-types.md
+++ b/docs/rules/prefer-immutable-types.md
@@ -2,7 +2,7 @@
 
 💼 This rule is enabled in the following configs: ☑️ `lite`, `no-mutations`, ✅ `recommended`, 🔒 `strict`.
 
-🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+🔧💡 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) and manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 <!-- end auto-generated rule header -->
 
@@ -178,22 +178,23 @@ type Options = {
     ignoreTypePattern?: string[] | string;
   };
 
-  fixer?:
-    | {
-        ReadonlyShallow?:
-          | { pattern: string; replace: string }
-          | Array<{ pattern: string; replace: string }>
-          | false;
-        ReadonlyDeep?:
-          | { pattern: string; replace: string }
-          | Array<{ pattern: string; replace: string }>
-          | false;
-        Immutable?:
-          | { pattern: string; replace: string }
-          | Array<{ pattern: string; replace: string }>
-          | false;
-      }
-    | false;
+  fixer?: {
+    ReadonlyShallow?:
+      | { pattern: string; replace: string }
+      | Array<{ pattern: string; replace: string }>;
+    ReadonlyDeep?:
+      | { pattern: string; replace: string }
+      | Array<{ pattern: string; replace: string }>;
+    Immutable?:
+      | { pattern: string; replace: string }
+      | Array<{ pattern: string; replace: string }>;
+  };
+
+  suggestions?: {
+    ReadonlyShallow?: Array<Array<{ pattern: string; replace: string }>>;
+    ReadonlyDeep?: Array<Array<{ pattern: string; replace: string }>>;
+    Immutable?: Array<Array<{ pattern: string; replace: string }>>;
+  };
 };
 ```
 
@@ -204,23 +205,25 @@ const defaults = {
   enforcement: "Immutable",
   ignoreClasses: false,
   ignoreInferredTypes: false,
-  fixer: {
+  fixer: false,
+  suggestions: {
     ReadonlyShallow: [
-      {
-        pattern: "^([_$a-zA-Z\\xA0-\\uFFFF][_$a-zA-Z0-9\\xA0-\\uFFFF]*\\[\\])$",
-        replace: "readonly $1",
-      },
-      {
-        pattern: "^(Array|Map|Set)<(.+)>$",
-        replace: "Readonly$1<$2>",
-      },
-      {
-        pattern: "^(.+)$",
-        replace: "Readonly<$1>",
-      },
+      [
+        {
+          pattern:
+            "^([_$a-zA-Z\\xA0-\\uFFFF][_$a-zA-Z0-9\\xA0-\\uFFFF]*\\[\\])$",
+          replace: "readonly $1",
+        },
+        {
+          pattern: "^(Array|Map|Set)<(.+)>$",
+          replace: "Readonly$1<$2>",
+        },
+        {
+          pattern: "^(.+)$",
+          replace: "Readonly<$1>",
+        },
+      ],
     ],
-    ReadonlyDeep: false,
-    Immutable: false,
   },
 };
 ```
@@ -384,7 +387,18 @@ If set to `false`, the fixer will be disabled.
 
 #### `fixer.*`
 
-By default we only configure the fixer to correct shallow readonly violations as TypeScript itself provides a utility type for this.
+Configure how the fixer should fix issue of each of the different enforcement levels.
+
+### `suggestions`
+
+This is the same as `fixer` but for manual suggestions instead of automatic fixers.
+If set to `false`, the no suggestions will be enabled.
+
+### `suggestions[*].*`
+
+Configure how the suggestion should fix issue of each of the different enforcement levels.
+
+By default we only configure the suggestions to correct shallow readonly violations as TypeScript itself provides a utility type for this.
 If you have access to other utility types (such as [type-fest's `ReadonlyDeep`](https://github.com/sindresorhus/type-fest#:~:text=set%20to%20optional.-,ReadonlyDeep,-%2D%20Create%20a%20deeply)), you can configure the fixer to use them with this option.
 
 Example using `ReadonlyDeep` instead of `Readonly`:
@@ -392,12 +406,14 @@ Example using `ReadonlyDeep` instead of `Readonly`:
 ```jsonc
 {
   // ...
-  "fixer": {
+  "suggestions": {
     "ReadonlyDeep": [
-      {
-        "pattern": "^(?:Readonly<(.+)>|(.+))$",
-        "replace": "ReadonlyDeep<$1$2>"
-      }
+      [
+        {
+          "pattern": "^(?:Readonly<(.+)>|(.+))$",
+          "replace": "ReadonlyDeep<$1$2>"
+        }
+      ]
     ]
   }
 }

--- a/tests/rules/prefer-immutable-types/ts/parameters/invalid.ts
+++ b/tests/rules/prefer-immutable-types/ts/parameters/invalid.ts
@@ -30,20 +30,30 @@ const tests: ReadonlyArray<InvalidTestCase> = [
   {
     code: "function foo(arg1: { foo: string }, arg2: { foo: number }) {}",
     optionsSet: [[{ parameters: "ReadonlyShallow" }]],
-    output:
-      "function foo(arg1: Readonly<{ foo: string }>, arg2: Readonly<{ foo: number }>) {}",
     errors: [
       {
         messageId: "parameter",
         type: "Identifier",
         line: 1,
         column: 14,
+        suggestions: [
+          {
+            output:
+              "function foo(arg1: Readonly<{ foo: string }>, arg2: { foo: number }) {}",
+          },
+        ],
       },
       {
         messageId: "parameter",
         type: "Identifier",
         line: 1,
         column: 37,
+        suggestions: [
+          {
+            output:
+              "function foo(arg1: { foo: string }, arg2: Readonly<{ foo: number }>) {}",
+          },
+        ],
       },
     ],
   },
@@ -151,47 +161,81 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       }
     `,
     optionsSet: [[]],
-    output: dedent`
-      class Klass {
-        constructor (
-          public readonly publicProp: string,
-          protected readonly protectedProp: string,
-          private readonly privateProp: string,
-      ) { }
-      }
-    `,
     errors: [
       {
         messageId: "propertyModifier",
         type: "TSParameterProperty",
         line: 3,
         column: 5,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                constructor (
+                  public readonly publicProp: string,
+                  protected protectedProp: string,
+                  private privateProp: string,
+              ) { }
+              }
+            `,
+          },
+        ],
       },
       {
         messageId: "propertyModifier",
         type: "TSParameterProperty",
         line: 4,
         column: 5,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                constructor (
+                  public publicProp: string,
+                  protected readonly protectedProp: string,
+                  private privateProp: string,
+              ) { }
+              }
+            `,
+          },
+        ],
       },
       {
         messageId: "propertyModifier",
         type: "TSParameterProperty",
         line: 5,
         column: 5,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                constructor (
+                  public publicProp: string,
+                  protected protectedProp: string,
+                  private readonly privateProp: string,
+              ) { }
+              }
+            `,
+          },
+        ],
       },
     ],
   },
   {
     code: "function foo(arg0: { foo: string | number }, arg1: { foo: string | number }): arg0 is { foo: number } {}",
     optionsSet: [[{ parameters: "ReadonlyShallow" }]],
-    output:
-      "function foo(arg0: { foo: string | number }, arg1: Readonly<{ foo: string | number }>): arg0 is { foo: number } {}",
     errors: [
       {
         messageId: "parameter",
         type: "Identifier",
         line: 1,
         column: 46,
+        suggestions: [
+          {
+            output:
+              "function foo(arg0: { foo: string | number }, arg1: Readonly<{ foo: string | number }>): arg0 is { foo: number } {}",
+          },
+        ],
       },
     ],
   },
@@ -215,48 +259,31 @@ const tests: ReadonlyArray<InvalidTestCase> = [
     optionsSet: [
       [
         {
-          parameters: "ReadonlyShallow",
-          fixer: {
-            ReadonlyDeep: {
-              pattern: "^(.+)$",
-              replace: "ReadonlyDeep<$1>",
-            },
-          },
-        },
-      ],
-    ],
-    output: "function foo(arg1: Readonly<{ foo: string }>) {}",
-    errors: [
-      {
-        messageId: "parameter",
-        type: "Identifier",
-        line: 1,
-        column: 14,
-      },
-    ],
-  },
-  {
-    code: "function foo(arg1: { foo: string }) {}",
-    optionsSet: [
-      [
-        {
           parameters: "ReadonlyDeep",
-          fixer: {
-            ReadonlyDeep: {
-              pattern: "^(.+)$",
-              replace: "ReadonlyDeep<$1>",
-            },
+          suggestions: {
+            ReadonlyDeep: [
+              [
+                {
+                  pattern: "^(.+)$",
+                  replace: "ReadonlyDeep<$1>",
+                },
+              ],
+            ],
           },
         },
       ],
     ],
-    output: "function foo(arg1: ReadonlyDeep<{ foo: string }>) {}",
     errors: [
       {
         messageId: "parameter",
         type: "Identifier",
         line: 1,
         column: 14,
+        suggestions: [
+          {
+            output: "function foo(arg1: ReadonlyDeep<{ foo: string }>) {}",
+          },
+        ],
       },
     ],
   },
@@ -266,22 +293,31 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       [
         {
           parameters: "ReadonlyDeep",
-          fixer: {
-            ReadonlyDeep: {
-              pattern: "^Readonly<(.+)>|(.+)$",
-              replace: "ReadonlyDeep<$1$2>",
-            },
+          suggestions: {
+            ReadonlyDeep: [
+              [
+                {
+                  pattern: "^Readonly<(.+)>|(.+)$",
+                  replace: "ReadonlyDeep<$1$2>",
+                },
+              ],
+            ],
           },
         },
       ],
     ],
-    output: "function foo(arg1: ReadonlyDeep<{ foo: { bar: string } }>) {}",
     errors: [
       {
         messageId: "parameter",
         type: "Identifier",
         line: 1,
         column: 14,
+        suggestions: [
+          {
+            output:
+              "function foo(arg1: ReadonlyDeep<{ foo: { bar: string } }>) {}",
+          },
+        ],
       },
     ],
   },
@@ -297,40 +333,86 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       function foo(arg: ReadonlyMap<string, string>) {}
     `,
     optionsSet: [[{ parameters: "ReadonlyShallow" }]],
-    output: dedent`
-      function foo(arg: ReadonlyArray<string>) {}
-      function foo(arg: readonly string[]) {}
-      function foo(arg: ReadonlySet<string>) {}
-      function foo(arg: ReadonlyMap<string, string>) {}
-      function foo(arg: ReadonlyArray<string>) {}
-      function foo(arg: readonly string[]) {}
-      function foo(arg: ReadonlySet<string>) {}
-      function foo(arg: ReadonlyMap<string, string>) {}
-    `,
     errors: [
       {
         messageId: "parameter",
         type: "Identifier",
         line: 1,
         column: 14,
+        suggestions: [
+          {
+            output: dedent`
+              function foo(arg: ReadonlyArray<string>) {}
+              function foo(arg: string[]) {}
+              function foo(arg: Set<string>) {}
+              function foo(arg: Map<string, string>) {}
+              function foo(arg: ReadonlyArray<string>) {}
+              function foo(arg: readonly string[]) {}
+              function foo(arg: ReadonlySet<string>) {}
+              function foo(arg: ReadonlyMap<string, string>) {}
+            `,
+          },
+        ],
       },
       {
         messageId: "parameter",
         type: "Identifier",
         line: 2,
         column: 14,
+        suggestions: [
+          {
+            output: dedent`
+              function foo(arg: Array<string>) {}
+              function foo(arg: readonly string[]) {}
+              function foo(arg: Set<string>) {}
+              function foo(arg: Map<string, string>) {}
+              function foo(arg: ReadonlyArray<string>) {}
+              function foo(arg: readonly string[]) {}
+              function foo(arg: ReadonlySet<string>) {}
+              function foo(arg: ReadonlyMap<string, string>) {}
+            `,
+          },
+        ],
       },
       {
         messageId: "parameter",
         type: "Identifier",
         line: 3,
         column: 14,
+        suggestions: [
+          {
+            output: dedent`
+              function foo(arg: Array<string>) {}
+              function foo(arg: string[]) {}
+              function foo(arg: ReadonlySet<string>) {}
+              function foo(arg: Map<string, string>) {}
+              function foo(arg: ReadonlyArray<string>) {}
+              function foo(arg: readonly string[]) {}
+              function foo(arg: ReadonlySet<string>) {}
+              function foo(arg: ReadonlyMap<string, string>) {}
+            `,
+          },
+        ],
       },
       {
         messageId: "parameter",
         type: "Identifier",
         line: 4,
         column: 14,
+        suggestions: [
+          {
+            output: dedent`
+              function foo(arg: Array<string>) {}
+              function foo(arg: string[]) {}
+              function foo(arg: Set<string>) {}
+              function foo(arg: ReadonlyMap<string, string>) {}
+              function foo(arg: ReadonlyArray<string>) {}
+              function foo(arg: readonly string[]) {}
+              function foo(arg: ReadonlySet<string>) {}
+              function foo(arg: ReadonlyMap<string, string>) {}
+            `,
+          },
+        ],
       },
     ],
   },

--- a/tests/rules/prefer-immutable-types/ts/return-types/invalid.ts
+++ b/tests/rules/prefer-immutable-types/ts/return-types/invalid.ts
@@ -51,24 +51,39 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       function foo(arg: unknown) {}
     `,
     optionsSet: [[{ returnTypes: "ReadonlyShallow" }]],
-    output: dedent`
-      function foo(arg: number): Readonly<{ foo: string }>;
-      function foo(arg: string): Readonly<{ foo: number }>;
-      function foo(arg: unknown): Readonly<{ foo: number }>;
-      function foo(arg: unknown) {}
-    `,
+
     errors: [
       {
         messageId: "returnType",
         type: "TSTypeAnnotation",
         line: 1,
         column: 26,
+        suggestions: [
+          {
+            output: dedent`
+              function foo(arg: number): Readonly<{ foo: string }>;
+              function foo(arg: string): Readonly<{ foo: number }>;
+              function foo(arg: unknown): { foo: number };
+              function foo(arg: unknown) {}
+            `,
+          },
+        ],
       },
       {
         messageId: "returnType",
         type: "TSTypeAnnotation",
         line: 3,
         column: 27,
+        suggestions: [
+          {
+            output: dedent`
+              function foo(arg: number): { foo: string };
+              function foo(arg: string): Readonly<{ foo: number }>;
+              function foo(arg: unknown): Readonly<{ foo: number }>;
+              function foo(arg: unknown) {}
+            `,
+          },
+        ],
       },
     ],
   },

--- a/tests/rules/prefer-immutable-types/ts/variables/invalid.ts
+++ b/tests/rules/prefer-immutable-types/ts/variables/invalid.ts
@@ -49,16 +49,20 @@ const tests: ReadonlyArray<InvalidTestCase> = [
             bar: { foo: number } = {} as any;
     `,
     optionsSet: [[{ variables: "ReadonlyShallow" }]],
-    output: dedent`
-      const foo: Readonly<{ foo: string }> = {} as any,
-            bar: Readonly<{ foo: number }> = {} as any;
-    `,
     errors: [
       {
         messageId: "variable",
         type: "Identifier",
         line: 2,
         column: 7,
+        suggestions: [
+          {
+            output: dedent`
+              const foo: Readonly<{ foo: string }> = {} as any,
+                    bar: Readonly<{ foo: number }> = {} as any;
+            `,
+          },
+        ],
       },
     ],
   },
@@ -147,38 +151,78 @@ const tests: ReadonlyArray<InvalidTestCase> = [
       }
     `,
     optionsSet: [[]],
-    output: dedent`
-      class Klass {
-        readonly foo: number;
-        private readonly bar: number;
-        static readonly baz: number;
-        private static readonly qux: number;
-      }
-    `,
     errors: [
       {
         messageId: "propertyModifier",
         type: "PropertyDefinition",
         line: 2,
         column: 3,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                readonly foo: number;
+                private bar: number;
+                static baz: number;
+                private static qux: number;
+              }
+            `,
+          },
+        ],
       },
       {
         messageId: "propertyModifier",
         type: "PropertyDefinition",
         line: 3,
         column: 3,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                foo: number;
+                private readonly bar: number;
+                static baz: number;
+                private static qux: number;
+              }
+            `,
+          },
+        ],
       },
       {
         messageId: "propertyModifier",
         type: "PropertyDefinition",
         line: 4,
         column: 3,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                foo: number;
+                private bar: number;
+                static readonly baz: number;
+                private static qux: number;
+              }
+            `,
+          },
+        ],
       },
       {
         messageId: "propertyModifier",
         type: "PropertyDefinition",
         line: 5,
         column: 3,
+        suggestions: [
+          {
+            output: dedent`
+              class Klass {
+                foo: number;
+                private bar: number;
+                static baz: number;
+                private static readonly qux: number;
+              }
+            `,
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
BREAKING CHANGE: The fixer config no longer inherits as many options as before; be sure to be
explicit in your configs.

fix #576