### PR TITLE
fix(prefer-immutable-types): support private identifier

### DIFF
--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -11,6 +11,7 @@ import {
   isExpressionStatement,
   isIdentifier,
   isMemberExpression,
+  isPrivateIdentifier,
   isThisExpression,
   isTSTypeAnnotation,
   isUnaryExpression,
@@ -48,31 +49,32 @@ function getNodeIdentifierText(
     return undefined;
   }
 
-  const identifierText = isIdentifier(node)
-    ? node.name
-    : hasID(node) && isDefined(node.id)
-    ? getNodeIdentifierText(node.id, context)
-    : hasKey(node) && isDefined(node.key)
-    ? getNodeIdentifierText(node.key, context)
-    : isAssignmentExpression(node)
-    ? getNodeIdentifierText(node.left, context)
-    : isMemberExpression(node)
-    ? `${getNodeIdentifierText(node.object, context)}.${getNodeIdentifierText(
-        node.property,
-        context
-      )}`
-    : isThisExpression(node)
-    ? "this"
-    : isUnaryExpression(node)
-    ? getNodeIdentifierText(node.argument, context)
-    : isExpressionStatement(node)
-    ? context.getSourceCode().getText(node as TSESTree.Node)
-    : isTSTypeAnnotation(node)
-    ? context
-        .getSourceCode()
-        .getText(node.typeAnnotation as TSESTree.Node)
-        .replaceAll(/\s+/gmu, "")
-    : null;
+  const identifierText =
+    isIdentifier(node) || isPrivateIdentifier(node)
+      ? node.name
+      : hasID(node) && isDefined(node.id)
+      ? getNodeIdentifierText(node.id, context)
+      : hasKey(node) && isDefined(node.key)
+      ? getNodeIdentifierText(node.key, context)
+      : isAssignmentExpression(node)
+      ? getNodeIdentifierText(node.left, context)
+      : isMemberExpression(node)
+      ? `${getNodeIdentifierText(node.object, context)}.${getNodeIdentifierText(
+          node.property,
+          context
+        )}`
+      : isThisExpression(node)
+      ? "this"
+      : isUnaryExpression(node)
+      ? getNodeIdentifierText(node.argument, context)
+      : isExpressionStatement(node)
+      ? context.getSourceCode().getText(node as TSESTree.Node)
+      : isTSTypeAnnotation(node)
+      ? context
+          .getSourceCode()
+          .getText(node.typeAnnotation as TSESTree.Node)
+          .replaceAll(/\s+/gmu, "")
+      : null;
 
   if (identifierText !== null) {
     return identifierText;

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -188,6 +188,12 @@ export function isObjectPattern(
   return node.type === AST_NODE_TYPES.ObjectPattern;
 }
 
+export function isPrivateIdentifier(
+  node: TSESTree.Node
+): node is TSESTree.PrivateIdentifier {
+  return node.type === AST_NODE_TYPES.PrivateIdentifier;
+}
+
 export function isProgram(node: TSESTree.Node): node is TSESTree.Program {
   return node.type === AST_NODE_TYPES.Program;
 }

--- a/tests/rules/prefer-immutable-types/ts/variables/valid.ts
+++ b/tests/rules/prefer-immutable-types/ts/variables/valid.ts
@@ -233,6 +233,7 @@ const tests: ReadonlyArray<ValidTestCase> = [
       class Klass {
         mutableA: number;
         private mutableB: number;
+        #mutableC: number;
       }
     `,
     optionsSet: [[{ ignoreNamePattern: "^mutable" }]],
@@ -249,6 +250,7 @@ const tests: ReadonlyArray<ValidTestCase> = [
       class Klass {
         AMutable: number;
         private BMutable: number;
+        #CMutable: number;
       }
     `,
     optionsSet: [[{ ignoreNamePattern: "Mutable$" }]],


### PR DESCRIPTION
## Proposed Changes

The `ignoreNamePattern` in `prefer-immutable-types` does not work with private class variables, but it should.