### PR TITLE
fix: typos in function names

### DIFF
--- a/src/rules/immutable-data.ts
+++ b/src/rules/immutable-data.ts
@@ -25,7 +25,7 @@ import {
 } from "#eslint-plugin-functional/utils/rule";
 import {
   findRootIdentifier,
-  isDefinedByMutableVaraible,
+  isDefinedByMutableVariable,
   isInConstructor,
 } from "#eslint-plugin-functional/utils/tree";
 import {
@@ -199,7 +199,7 @@ function checkAssignmentExpression(
     const rootIdentifier = findRootIdentifier(node.left.object);
     if (
       rootIdentifier !== undefined &&
-      isDefinedByMutableVaraible(rootIdentifier, context)
+      isDefinedByMutableVariable(rootIdentifier, context)
     ) {
       return {
         context,
@@ -252,7 +252,7 @@ function checkUnaryExpression(
     const rootIdentifier = findRootIdentifier(node.argument.object);
     if (
       rootIdentifier !== undefined &&
-      isDefinedByMutableVaraible(rootIdentifier, context)
+      isDefinedByMutableVariable(rootIdentifier, context)
     ) {
       return {
         context,
@@ -304,7 +304,7 @@ function checkUpdateExpression(
     const rootIdentifier = findRootIdentifier(node.argument.object);
     if (
       rootIdentifier !== undefined &&
-      isDefinedByMutableVaraible(rootIdentifier, context)
+      isDefinedByMutableVariable(rootIdentifier, context)
     ) {
       return {
         context,
@@ -400,7 +400,7 @@ function checkCallExpression(
       const rootIdentifier = findRootIdentifier(node.callee.object);
       if (
         rootIdentifier === undefined ||
-        !isDefinedByMutableVaraible(rootIdentifier, context)
+        !isDefinedByMutableVariable(rootIdentifier, context)
       ) {
         return {
           context,
@@ -434,7 +434,7 @@ function checkCallExpression(
       const rootIdentifier = findRootIdentifier(node.callee.object);
       if (
         rootIdentifier === undefined ||
-        !isDefinedByMutableVaraible(rootIdentifier, context)
+        !isDefinedByMutableVariable(rootIdentifier, context)
       ) {
         return {
           context,

--- a/src/rules/prefer-immutable-types.ts
+++ b/src/rules/prefer-immutable-types.ts
@@ -342,12 +342,12 @@ function getAllFixers(
   const fix =
     fixerConfigs === false
       ? null
-      : getConfiuredFixer(node, nodeText, fixerConfigs);
+      : getConfiguredFixer(node, nodeText, fixerConfigs);
 
   const suggestionFixers =
     suggestionsConfigs === false
       ? null
-      : getConfiuredSuggestionFixers(node, nodeText, suggestionsConfigs);
+      : getConfiguredSuggestionFixers(node, nodeText, suggestionsConfigs);
 
   return { fix, suggestionFixers };
 }
@@ -355,7 +355,7 @@ function getAllFixers(
 /**
  * Get a fixer that uses the user config.
  */
-function getConfiuredFixer(
+function getConfiguredFixer(
   node: TSESTree.Node,
   text: string,
   configs: FixerConfig[],
@@ -371,7 +371,7 @@ function getConfiuredFixer(
 /**
  * Get a fixer that uses the user config.
  */
-function getConfiuredSuggestionFixers(
+function getConfiguredSuggestionFixers(
   node: TSESTree.Node,
   text: string,
   suggestionsConfigs: SuggestionsConfig[],
@@ -751,7 +751,7 @@ function checkFunction(
 /**
  * Check if the given function node violates this rule.
  */
-function checkVarible(
+function checkVariable(
   node: TSESTree.VariableDeclarator | TSESTree.PropertyDefinition,
   context: Readonly<RuleContext<keyof typeof errorMessages, Options>>,
   options: Readonly<Options>,
@@ -931,7 +931,7 @@ export const rule = createRule<keyof typeof errorMessages, Options>(
     TSEmptyBodyFunctionExpression: checkFunction,
     TSFunctionType: checkFunction,
     TSMethodSignature: checkFunction,
-    PropertyDefinition: checkVarible,
-    VariableDeclarator: checkVarible,
+    PropertyDefinition: checkVariable,
+    VariableDeclarator: checkVariable,
   },
 );

--- a/src/rules/type-declaration-immutability.ts
+++ b/src/rules/type-declaration-immutability.ts
@@ -272,7 +272,7 @@ function getRuleToApply(
 /**
  * Get a fixer that uses the user config.
  */
-function getConfiuredFixer<T extends TSESTree.Node>(
+function getConfiguredFixer<T extends TSESTree.Node>(
   node: T,
   context: Readonly<RuleContext<keyof typeof errorMessages, Options>>,
   configs: FixerConfig[],
@@ -329,7 +329,7 @@ function getResults(
   const fix =
     rule.fixers === false || isTSInterfaceDeclaration(node)
       ? null
-      : getConfiuredFixer(node.typeAnnotation, context, rule.fixers);
+      : getConfiguredFixer(node.typeAnnotation, context, rule.fixers);
 
   return {
     context,

--- a/src/utils/tree.ts
+++ b/src/utils/tree.ts
@@ -271,7 +271,7 @@ export function getKeyOfValueInObjectExpression(
 /**
  * Is the given identifier defined by a mutable variable (let or var)?
  */
-export function isDefinedByMutableVaraible<
+export function isDefinedByMutableVariable<
   Context extends RuleContext<string, BaseOptions>,
 >(node: TSESTree.Identifier, context: Context) {
   const services = getParserServices(context);


### PR DESCRIPTION
Fix some typos found in function names