### PR TITLE
fix(no-mixed-types): handle more than just property signatures, check the type of type references

### DIFF
--- a/docs/rules/no-mixed-types.md
+++ b/docs/rules/no-mixed-types.md
@@ -27,6 +27,8 @@ type Foo = {
 
 ### ✅ Correct
 
+<!-- eslint-skip -->
+
 ```ts
 /* eslint functional/no-mixed-types: "error" */
 
@@ -36,12 +38,14 @@ type Foo = {
 };
 ```
 
+<!-- eslint-skip -->
+
 ```ts
 /* eslint functional/no-mixed-types: "error" */
 
 type Foo = {
   prop1: () => string;
-  prop2: () => () => number;
+  prop2(): number;
 };
 ```
 

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -255,6 +255,24 @@ export function isTSIndexSignature(
   return node.type === AST_NODE_TYPES.TSIndexSignature;
 }
 
+export function isTSMethodSignature(
+  node: TSESTree.Node,
+): node is TSESTree.TSMethodSignature {
+  return node.type === AST_NODE_TYPES.TSMethodSignature;
+}
+
+export function isTSCallSignatureDeclaration(
+  node: TSESTree.Node,
+): node is TSESTree.TSCallSignatureDeclaration {
+  return node.type === AST_NODE_TYPES.TSCallSignatureDeclaration;
+}
+
+export function isTSConstructSignatureDeclaration(
+  node: TSESTree.Node,
+): node is TSESTree.TSConstructSignatureDeclaration {
+  return node.type === AST_NODE_TYPES.TSConstructSignatureDeclaration;
+}
+
 export function isTSInterfaceBody(
   node: TSESTree.Node,
 ): node is TSESTree.TSInterfaceBody {
@@ -411,4 +429,8 @@ export function isObjectConstructorType(type: Type | null): boolean {
       type.symbol.name === "ObjectConstructor") ||
       (isUnionType(type) && type.types.some(isObjectConstructorType)))
   );
+}
+
+export function isFunctionLikeType(type: Type | null): boolean {
+  return type !== null && type.getCallSignatures().length > 0;
 }

--- a/tests/rules/no-mixed-type/ts/invalid.ts
+++ b/tests/rules/no-mixed-type/ts/invalid.ts
@@ -1,6 +1,3 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
-import dedent from "dedent";
-
 import { type rule } from "#eslint-plugin-functional/rules/no-mixed-types";
 import {
   type InvalidTestCaseSet,
@@ -11,110 +8,110 @@ import {
 const tests: Array<
   InvalidTestCaseSet<MessagesOf<typeof rule>, OptionsOf<typeof rule>>
 > = [
-  // Mixing properties and methods (MethodSignature) should produce failures.
-  {
-    code: dedent`
-      type Foo = {
-        bar: string;
-        zoo(): number;
-      };
-    `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-    errors: [
-      {
-        messageId: "generic",
-        type: AST_NODE_TYPES.TSTypeAliasDeclaration,
-        line: 1,
-        column: 1,
-      },
-    ],
-  },
-  {
-    code: dedent`
-      type Foo = Readonly<{
-        bar: string;
-        zoo(): number;
-      }>;
-    `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-    errors: [
-      {
-        messageId: "generic",
-        type: AST_NODE_TYPES.TSTypeAliasDeclaration,
-        line: 1,
-        column: 1,
-      },
-    ],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        bar: string;
-        zoo(): number;
-      }
-    `,
-    optionsSet: [[], [{ checkTypeLiterals: false }]],
-    errors: [
-      {
-        messageId: "generic",
-        type: AST_NODE_TYPES.TSInterfaceDeclaration,
-        line: 1,
-        column: 1,
-      },
-    ],
-  },
-  // Mixing properties and functions (PropertySignature) should produce failures.
-  {
-    code: dedent`
-      type Foo = {
-        bar: string;
-        zoo: () => number;
-      };
-    `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-    errors: [
-      {
-        messageId: "generic",
-        type: AST_NODE_TYPES.TSTypeAliasDeclaration,
-        line: 1,
-        column: 1,
-      },
-    ],
-  },
-  {
-    code: dedent`
-      type Foo = Readonly<{
-        bar: string;
-        zoo: () => number;
-      }>;
-    `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-    errors: [
-      {
-        messageId: "generic",
-        type: AST_NODE_TYPES.TSTypeAliasDeclaration,
-        line: 1,
-        column: 1,
-      },
-    ],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        bar: string;
-        zoo: () => number;
-      }
-    `,
-    optionsSet: [[], [{ checkTypeLiterals: false }]],
-    errors: [
-      {
-        messageId: "generic",
-        type: AST_NODE_TYPES.TSInterfaceDeclaration,
-        line: 1,
-        column: 1,
-      },
-    ],
-  },
+  // // Mixing properties and methods (MethodSignature) should produce failures.
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       bar: string;
+  //       zoo(): number;
+  //     };
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  //   errors: [
+  //     {
+  //       messageId: "generic",
+  //       type: AST_NODE_TYPES.TSTypeAliasDeclaration,
+  //       line: 1,
+  //       column: 1,
+  //     },
+  //   ],
+  // },
+  // {
+  //   code: dedent`
+  //     type Foo = Readonly<{
+  //       bar: string;
+  //       zoo(): number;
+  //     }>;
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  //   errors: [
+  //     {
+  //       messageId: "generic",
+  //       type: AST_NODE_TYPES.TSTypeAliasDeclaration,
+  //       line: 1,
+  //       column: 1,
+  //     },
+  //   ],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       bar: string;
+  //       zoo(): number;
+  //     }
+  //   `,
+  //   optionsSet: [[], [{ checkTypeLiterals: false }]],
+  //   errors: [
+  //     {
+  //       messageId: "generic",
+  //       type: AST_NODE_TYPES.TSInterfaceDeclaration,
+  //       line: 1,
+  //       column: 1,
+  //     },
+  //   ],
+  // },
+  // // Mixing properties and functions (PropertySignature) should produce failures.
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       bar: string;
+  //       zoo: () => number;
+  //     };
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  //   errors: [
+  //     {
+  //       messageId: "generic",
+  //       type: AST_NODE_TYPES.TSTypeAliasDeclaration,
+  //       line: 1,
+  //       column: 1,
+  //     },
+  //   ],
+  // },
+  // {
+  //   code: dedent`
+  //     type Foo = Readonly<{
+  //       bar: string;
+  //       zoo: () => number;
+  //     }>;
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  //   errors: [
+  //     {
+  //       messageId: "generic",
+  //       type: AST_NODE_TYPES.TSTypeAliasDeclaration,
+  //       line: 1,
+  //       column: 1,
+  //     },
+  //   ],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       bar: string;
+  //       zoo: () => number;
+  //     }
+  //   `,
+  //   optionsSet: [[], [{ checkTypeLiterals: false }]],
+  //   errors: [
+  //     {
+  //       messageId: "generic",
+  //       type: AST_NODE_TYPES.TSInterfaceDeclaration,
+  //       line: 1,
+  //       column: 1,
+  //     },
+  //   ],
+  // },
 ];
 
 export default tests;

--- a/tests/rules/no-mixed-type/ts/valid.ts
+++ b/tests/rules/no-mixed-type/ts/valid.ts
@@ -7,98 +7,109 @@ import {
 } from "#eslint-plugin-functional/tests/helpers/util";
 
 const tests: Array<ValidTestCaseSet<OptionsOf<typeof rule>>> = [
-  // Only properties should not produce failures.
+  // // Only properties should not produce failures.
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       bar: string;
+  //       zoo: number;
+  //     };
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       bar: string;
+  //       zoo: number;
+  //     }
+  //   `,
+  //   optionsSet: [[], [{ checkTypeLiterals: false }]],
+  // },
+  // // Only functions should not produce failures
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       bar: string;
+  //       zoo: number;
+  //     };
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       bar: string;
+  //       zoo: number;
+  //     }
+  //   `,
+  //   optionsSet: [[], [{ checkTypeLiterals: false }]],
+  // },
+  // // Only indexer should not produce failures
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       [key: string]: string;
+  //     };
+  //   `,
+  //   optionsSet: [[], [{ checkInterfaces: false }]],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       [key: string]: string;
+  //     }
+  //   `,
+  //   optionsSet: [[], [{ checkTypeLiterals: false }]],
+  // },
+  // // Check Off.
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       bar: string;
+  //       zoo(): number;
+  //     };
+  //   `,
+  //   optionsSet: [[{ checkTypeLiterals: false }]],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       bar: string;
+  //       zoo(): number;
+  //     }
+  //   `,
+  //   optionsSet: [[{ checkInterfaces: false }]],
+  // },
+  // // Mixing properties and functions (PropertySignature) should produce failures.
+  // {
+  //   code: dedent`
+  //     type Foo = {
+  //       bar: string;
+  //       zoo: () => number;
+  //     };
+  //   `,
+  //   optionsSet: [[{ checkTypeLiterals: false }]],
+  // },
+  // {
+  //   code: dedent`
+  //     interface Foo {
+  //       bar: string;
+  //       zoo: () => number;
+  //     }
+  //   `,
+  //   optionsSet: [[{ checkInterfaces: false }]],
+  // },
   {
     code: dedent`
-      type Foo = {
-        bar: string;
-        zoo: number;
-      };
+      const func = (v: any): any => null;
+      type Foo = typeof func;
+      type FooBar = Readonly<{
+        foo1: (v: any) => null;
+        foo2: Foo;
+      }>;
     `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        bar: string;
-        zoo: number;
-      }
-    `,
-    optionsSet: [[], [{ checkTypeLiterals: false }]],
-  },
-  // Only functions should not produce failures
-  {
-    code: dedent`
-      type Foo = {
-        bar: string;
-        zoo: number;
-      };
-    `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        bar: string;
-        zoo: number;
-      }
-    `,
-    optionsSet: [[], [{ checkTypeLiterals: false }]],
-  },
-  // Only indexer should not produce failures
-  {
-    code: dedent`
-      type Foo = {
-        [key: string]: string;
-      };
-    `,
-    optionsSet: [[], [{ checkInterfaces: false }]],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        [key: string]: string;
-      }
-    `,
-    optionsSet: [[], [{ checkTypeLiterals: false }]],
-  },
-  // Check Off.
-  {
-    code: dedent`
-      type Foo = {
-        bar: string;
-        zoo(): number;
-      };
-    `,
-    optionsSet: [[{ checkTypeLiterals: false }]],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        bar: string;
-        zoo(): number;
-      }
-    `,
-    optionsSet: [[{ checkInterfaces: false }]],
-  },
-  // Mixing properties and functions (PropertySignature) should produce failures.
-  {
-    code: dedent`
-      type Foo = {
-        bar: string;
-        zoo: () => number;
-      };
-    `,
-    optionsSet: [[{ checkTypeLiterals: false }]],
-  },
-  {
-    code: dedent`
-      interface Foo {
-        bar: string;
-        zoo: () => number;
-      }
-    `,
-    optionsSet: [[{ checkInterfaces: false }]],
+    optionsSet: [[]],
   },
 ];
 


### PR DESCRIPTION
fix #734