### PR TITLE
fix(prefer-tacit): don't check member functions by default

### DIFF
--- a/docs/rules/prefer-tacit.md
+++ b/docs/rules/prefer-tacit.md
@@ -41,4 +41,60 @@ function f(x) {
 }
 
 const foo = [1, 2, 3].map(f);
+
+const bar = { f };
+const baz = [1, 2, 3].map((x) => bar.f(x)); // Allowed unless using `checkMemberExpressions`
+```
+
+## Options
+
+This rule accepts an options object of the following type:
+
+```ts
+type Options = {
+  checkMemberExpressions: boolean;
+};
+```
+
+### Default Options
+
+```ts
+type Options = {
+  checkMemberExpressions: false;
+};
+```
+
+### `checkMemberExpressions`
+
+If `true`, calls of member expressions are checked as well.
+If `false`, only calls of identifiers are checked.
+
+#### ❌ Incorrect
+
+<!-- eslint-skip -->
+
+```ts
+/* eslint functional/prefer-tacit: ["error", { "checkMemberExpressions": true }] */
+
+const bar = {
+  f(x) {
+    return x + 1;
+  }
+}
+
+const foo = [1, 2, 3].map((x) => bar.f(x));
+```
+
+#### ✅ Correct
+
+```ts
+/* eslint functional/prefer-tacit: ["error", { "checkMemberExpressions": true }] */
+
+const bar = {
+  f(x) {
+    return x + 1;
+  }
+}
+
+const foo = [1, 2, 3].map(bar.f.bind(bar));
 ```

--- a/tests/rules/prefer-tacit/ts/invalid.ts
+++ b/tests/rules/prefer-tacit/ts/invalid.ts
@@ -293,6 +293,53 @@ const tests: Array<
       },
     ],
   },
+  // Member Call Expression
+  {
+    code: dedent`
+      [''].filter(str => /a/.test(str));
+    `,
+    optionsSet: [[{ checkMemberExpressions: true }]],
+    errors: [
+      {
+        messageId: "generic",
+        type: AST_NODE_TYPES.ArrowFunctionExpression,
+        line: 1,
+        column: 13,
+        suggestions: [
+          {
+            messageId: "generic",
+            output: dedent`
+              [''].filter(/a/.test.bind(/a/));
+            `,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    code: dedent`
+      declare const a: { b(arg: string): string; };
+      function foo(x) { return a.b(x); }
+    `,
+    optionsSet: [[{ checkMemberExpressions: true }]],
+    errors: [
+      {
+        messageId: "generic",
+        type: AST_NODE_TYPES.FunctionDeclaration,
+        line: 2,
+        column: 1,
+        suggestions: [
+          {
+            messageId: "generic",
+            output: dedent`
+              declare const a: { b(arg: string): string; };
+              const foo = a.b.bind(a);
+            `,
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 export default tests;

--- a/tests/rules/prefer-tacit/ts/valid.ts
+++ b/tests/rules/prefer-tacit/ts/valid.ts
@@ -86,6 +86,20 @@ const tests: Array<ValidTestCaseSet<OptionsOf<typeof rule>>> = [
     dependencyConstraints: { typescript: "4.7.0" },
     optionsSet: [[]],
   },
+  // Member Call Expression
+  {
+    code: dedent`
+      [''].filter(str => /a/.test(str))
+    `,
+    optionsSet: [[{ checkMemberExpressions: false }]],
+  },
+  {
+    code: dedent`
+      declare const a: { b(arg: string): string; };
+      function foo(x) { return a.b(x); }
+    `,
+    optionsSet: [[{ checkMemberExpressions: false }]],
+  },
 ];
 
 export default tests;


### PR DESCRIPTION
fix #805