### PR TITLE
feat(no-throw-statements)!: replace option `allowInAsyncFunctions` with `allowToRejectPromises`

### DIFF
--- a/docs/rules/no-throw-statements.md
+++ b/docs/rules/no-throw-statements.md
@@ -28,8 +28,6 @@ throw new Error("Something went wrong.");
 
 ### ✅ Correct
 
-<!-- eslint-skip -->
-
 ```js
 /* eslint functional/no-throw-statements: "error" */
 
@@ -37,8 +35,6 @@ function divide(x, y) {
   return y === 0 ? new Error("Cannot divide by zero.") : x / y;
 }
 ```
-
-<!-- eslint-skip -->
 
 ```js
 /* eslint functional/no-throw-statements: "error" */
@@ -58,7 +54,7 @@ This rule accepts an options object of the following type:
 
 ```ts
 type Options = {
-  allowInAsyncFunctions: boolean;
+  allowToRejectPromises: boolean;
 };
 ```
 
@@ -66,7 +62,7 @@ type Options = {
 
 ```ts
 const defaults = {
-  allowInAsyncFunctions: false,
+  allowToRejectPromises: false,
 };
 ```
 
@@ -76,19 +72,19 @@ const defaults = {
 
 ```ts
 const recommendedAndLiteOptions = {
-  allowInAsyncFunctions: true,
+  allowToRejectPromises: true,
 };
 ```
 
-### `allowInAsyncFunctions`
+### `allowToRejectPromises`
 
-If true, throw statements will be allowed within async functions.\
+If true, throw statements will be allowed when they are used to reject a promise, such when in an async function.\
 This essentially allows throw statements to be used as return statements for errors.
 
 #### ✅ Correct
 
 ```js
-/* eslint functional/no-throw-statements: ["error", { "allowInAsyncFunctions": true }] */
+/* eslint functional/no-throw-statements: ["error", { "allowToRejectPromises": true }] */
 
 async function divide(x, y) {
   const [xv, yv] = await Promise.all([x, y]);

--- a/docs/rules/prefer-immutable-types.md
+++ b/docs/rules/prefer-immutable-types.md
@@ -425,7 +425,7 @@ acceptsCallback((options: CallbackOptions) => {});
 
 ```ts
 export interface CallbackOptions {
-  prop: string;
+  readonly prop: string;
 }
 type Callback = (options: CallbackOptions) => void;
 type AcceptsCallback = (callback: Callback) => void;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,12 @@ export default rsEslint(
       },
     },
     formatters: true,
-    functional: "lite",
+    functional: {
+      functionalEnforcement: "lite",
+      overrides: {
+        "functional/no-throw-statements": "off",
+      },
+    },
     jsonc: true,
     markdown: {
       enableTypeRequiredRules: true,
@@ -50,9 +55,6 @@ export default rsEslint(
     rules: {
       // Some types say they have nonnullable properties, but they don't always.
       "ts/no-unnecessary-condition": "off",
-
-      // Temp
-      "functional/no-throw-statements": "off",
     },
   },
   {

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -66,7 +66,7 @@ const overrides = {
   [noThrowStatements.fullName]: [
     "error",
     {
-      allowInAsyncFunctions: true,
+      allowToRejectPromises: true,
     },
   ],
   [noTryStatements.fullName]: "off",

--- a/tests/rules/no-throw-statements.test.ts
+++ b/tests/rules/no-throw-statements.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { name, rule } from "#/rules/no-throw-statements";
 
-import { esLatestConfig } from "../utils/configs";
+import { esLatestConfig, typescriptConfig } from "../utils/configs";
 
 describe(name, () => {
   describe("javascript - es latest", () => {
@@ -56,6 +56,121 @@ describe(name, () => {
         errors: ["generic"],
       });
       expect(invalidResult.messages).toMatchSnapshot();
+    });
+
+    describe("options", () => {
+      describe("allowToRejectPromises", () => {
+        it("doesn't report throw statements in async functions", () => {
+          valid({
+            code: dedent`
+              async function foo() {
+                throw new Error();
+              }
+            `,
+            options: [{ allowToRejectPromises: true }],
+          });
+        });
+
+        it("doesn't report throw statements in try without catch in async functions", () => {
+          valid({
+            code: dedent`
+              async function foo() {
+                try {
+                  throw new Error("hello");
+                } finally {
+                  console.log("world");
+                }
+              }
+            `,
+            options: [{ allowToRejectPromises: true }],
+          });
+        });
+
+        it("reports throw statements in try with catch in async functions", () => {
+          const invalidResult = invalid({
+            code: dedent`
+              async function foo() {
+                try {
+                  throw new Error("hello world");
+                } catch (e) {
+                  console.log(e);
+                }
+              }
+            `,
+            errors: ["generic"],
+            options: [{ allowToRejectPromises: true }],
+          });
+          expect(invalidResult.messages).toMatchSnapshot();
+        });
+
+        it("reports throw statements in functions nested in async functions", () => {
+          const invalidResult = invalid({
+            code: dedent`
+              async function foo() {
+                function bar() {
+                  throw new Error();
+                }
+              }
+            `,
+            errors: ["generic"],
+            options: [{ allowToRejectPromises: true }],
+          });
+          expect(invalidResult.messages).toMatchSnapshot();
+        });
+      });
+    });
+  });
+
+  describe("typescript", () => {
+    const { valid, invalid } = createRuleTester({
+      name,
+      rule,
+      configs: typescriptConfig,
+    });
+
+    describe("options", () => {
+      describe("allowToRejectPromises", () => {
+        it("doesn't report throw statements in promise then handlers", () => {
+          valid({
+            code: dedent`
+              function foo() {
+                Promise.resolve().then(() => {
+                  throw new Error();
+                });
+              }
+            `,
+            options: [{ allowToRejectPromises: true }],
+          });
+        });
+
+        it("doesn't report throw statements in promise catch handlers", () => {
+          valid({
+            code: dedent`
+              function foo() {
+                Promise.resolve().catch(() => {
+                  throw new Error();
+                });
+              }
+            `,
+            options: [{ allowToRejectPromises: true }],
+          });
+        });
+
+        it("doesn't report throw statements in promise handlers", () => {
+          valid({
+            code: dedent`
+              function foo() {
+                Promise.resolve().then(() => {
+                  throw new Error();
+                }, () => {
+                  throw new Error();
+                });
+              }
+            `,
+            options: [{ allowToRejectPromises: true }],
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
fix #838 