### PR TITLE
fix(no-conditional-statements): allow continue and break statements with labels to be considered "returning"

### DIFF
--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -157,6 +157,12 @@ export function isIfStatement(
   return node.type === AST_NODE_TYPES.IfStatement;
 }
 
+export function isLabeledStatement(
+  node: TSESTree.Node,
+): node is TSESTree.LabeledStatement {
+  return node.type === AST_NODE_TYPES.LabeledStatement;
+}
+
 export function isMemberExpression(
   node: TSESTree.Node,
 ): node is TSESTree.MemberExpression {


### PR DESCRIPTION
Handle labeled break statements and continue statements in switch cases in the no-conditional-statements rule.
