### PR TITLE
fix: mark no-throw-statements rule as requiring type checking

### DIFF
--- a/src/rules/no-throw-statements.ts
+++ b/src/rules/no-throw-statements.ts
@@ -66,7 +66,7 @@ const meta: NamedCreateRuleCustomMeta<keyof typeof errorMessages, RawOptions> = 
     description: "Disallow throwing exceptions.",
     recommended: "recommended",
     recommendedSeverity: "error",
-    requiresTypeChecking: false,
+    requiresTypeChecking: true,
   },
   messages: errorMessages,
   schema,


### PR DESCRIPTION
Previously, the rule `functional/no-throw-statements` did not declare `requiresTypeChecking: true`, which caused runtime errors when using it with `@typescript-eslint` without a `parserOptions.project` set.

This change adds `requiresTypeChecking: true` to the rule's meta to align with its actual type-dependent behavior.