### PR TITLE
fix(deps): update deepmerge-ts to ^8

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@typescript-eslint/utils": "^8.26.0",
-    "deepmerge-ts": "^7.1.5",
+    "deepmerge-ts": "^8.0.0",
     "escape-string-regexp": "^5.0.0",
     "is-immutable-type": "^5.0.1",
     "ts-api-utils": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^8.26.0
         version: 8.60.1(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
       deepmerge-ts:
-        specifier: ^7.1.5
-        version: 7.1.5
+        specifier: ^8.0.0
+        version: 8.0.2
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2381,9 +2381,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
+  deepmerge-ts@8.0.2:
+    resolution: {integrity: sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==}
+    engines: {node: '>=16.9.0'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -6306,7 +6306,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.2: {}
 
   deepmerge@4.3.1: {}
 


### PR DESCRIPTION
Closes #1093.

### Problem

`deepmerge-ts@<8.0.0` is affected by GHSA-ggr8-5vv4-36mx / CVE-2026-40345 (stack exhaustion when merging recursive object graphs). This bumps the dependency range to `^8.0.0`.

### Is the major bump safe? Yes.

The plugin imports only the plain `deepmerge()` function and uses it solely to merge JSON-schema option objects and user-provided rule options (`src/utils/schemas.ts`, `src/options/overrides.ts`, and the option schemas in `src/rules/*.ts`).

None of the v8 breaking changes apply:

| v8 breaking change | Used here? |
| --- | --- |
| `deepmergeInto` no longer leak-mutates inputs | No — not imported |
| `deepmergeCustom` / `MetaDataUpdater` renames (`metaMeta`→`mergeInfo`, `MM`→`MI`) | No — `deepmergeCustom` not used |
| `DeepMergeMetaMetaData`→`DeepMergeMergeInfo`, `DeepMergeIntoFunctionUtils`→`DeepMergeIntoUtils` | No — no deepmerge-ts types imported |
| Deep Map value merging / `mergeMaps` collision merging | No — only plain objects/arrays merged |

The default merge strategy and signature of `deepmerge()` for plain objects and arrays are unchanged in v8; the only behavioural change relevant here is that recursive graphs no longer overflow the stack.

`deepmerge-ts@8` requires Node `>=16.9.0`; this repo already requires `>=20.0.0`.

### Verification

`pnpm typecheck` and `pnpm test:js` (27 files, 381 tests) pass locally.
